### PR TITLE
Remove personal LLM configuration details

### DIFF
--- a/config/llm.json
+++ b/config/llm.json
@@ -1,8 +1,7 @@
 {
-  "endpoint": "http://26.112.115.236:1234/v1/chat/completions",
+  "endpoint": "http://localhost:1234/v1/chat/completions",
   "model": "qwen3-4b-thinking-2507",
   "max_context": -1,
-  "api_key": "",
   "extra_headers": {},
   "memory": {
     "perception_buffer_size": 30,

--- a/engine/llm_client.py
+++ b/engine/llm_client.py
@@ -22,7 +22,6 @@ class LLMClient:
                 "endpoint": "http://localhost:11434/v1/chat/completions",
                 "model": "gpt-4o-mini",
                 "max_output_tokens": 256,
-                "api_key": "",
                 "extra_headers": {},
             }
         except Exception as e:
@@ -31,7 +30,6 @@ class LLMClient:
                 "endpoint": "http://localhost:11434/v1/chat/completions",
                 "model": "gpt-4o-mini",
                 "max_output_tokens": 256,
-                "api_key": "",
                 "extra_headers": {},
             }
         self.endpoint = cfg.get("endpoint")

--- a/exports/monolith.txt
+++ b/exports/monolith.txt
@@ -193,7 +193,6 @@ class LLMClient:
                 "endpoint": "http://localhost:11434/v1/chat/completions",
                 "model": "gpt-4o-mini",
                 "max_output_tokens": 256,
-                "api_key": "",
                 "extra_headers": {},
             }
         except Exception as e:
@@ -202,7 +201,6 @@ class LLMClient:
                 "endpoint": "http://localhost:11434/v1/chat/completions",
                 "model": "gpt-4o-mini",
                 "max_output_tokens": 256,
-                "api_key": "",
                 "extra_headers": {},
             }
         self.endpoint = cfg.get("endpoint")


### PR DESCRIPTION
## Summary
- Replace hard-coded LLM endpoint IP with localhost
- Drop stored API key field from configuration
- Remove API key defaults from engine and monolith export

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a81100a8d8832ea9fe6b2735687fcf