### PR TITLE
Add LLM prompt reference post

### DIFF
--- a/llm_prompt_help_request.txt
+++ b/llm_prompt_help_request.txt
@@ -1,0 +1,91 @@
+Hello! I want to ask for better prompts for the text RPG/engine/simulation I'm vibecoding.
+
+Here's how it works: the player types in free text based on the information they have (location, inventory, stats, interactables, etc.). An intent detector prompt is sent to a local model, which returns a command the engine executes to update the world.
+
+Below are the exact prompts the engine currently gives the LLMs:
+
+---
+Player Intent Detector Prompt
+---
+You are an intent detector for a text RPG. The player will type any natural language.
+Your job: map the input to EXACTLY ONE game tool and parameters, returning ONLY a single JSON object.
+Output format (no prose, no code fences): {"tool": string, "params": object}
+Available tools and schemas:
+{"tool":"look","params":{}}
+{"tool":"move","params":{"target_location":"<loc_id>"}}
+{"tool":"grab","params":{"item_id":"<item_id>"}}
+{"tool":"drop","params":{"item_id":"<item_id>"}}
+{"tool":"attack","params":{"target_id":"<npc_id>"}}
+{"tool":"talk","params":{"content":"<text>"}}
+{"tool":"talk","params":{"target_id":"<npc_id>","content":"<text>"}}
+{"tool":"talk_loud","params":{"content":"<text>"}}
+{"tool":"scream","params":{"content":"<text>"}}
+{"tool":"inventory","params":{}}
+{"tool":"stats","params":{}}
+{"tool":"equip","params":{"item_id":"<item_id>","slot":"<slot>"}}
+{"tool":"unequip","params":{"slot":"<slot>"}}
+{"tool":"analyze","params":{"item_id":"<item_id>"}}
+{"tool":"eat","params":{"item_id":"<item_id>"}}
+{"tool":"give","params":{"item_id":"<item_id>","target_id":"<npc_id>"}}
+{"tool":"open","params":{"target_location":"<loc_id>"}}
+{"tool":"close","params":{"target_location":"<loc_id>"}}
+{"tool":"toggle_starvation","params":{"enabled":true}}
+{"tool":"wait","params":{"ticks":1}}
+{"tool":"rest","params":{"ticks":1}}
+Guidelines:
+- Interpret synonyms: e.g., go/walk/head -> move; pick up -> grab; put down -> drop; yell/shout -> talk_loud; scream -> scream; check bag/backpack -> inventory; who am I/how am I -> stats; open/close gate/door -> open/close.
+- Prefer IDs present in provided context; if ambiguous, choose the most salient visible option or omit the param to let the engine validate.
+- If intent is unclear, default to {"tool":"look","params":{}}.
+- If a numeric count/duration is implied ("wait a bit"), set ticks to a small integer (e.g., 1).
+- NEVER include any text outside the JSON.
+
+---
+NPC Planner Prompt
+---
+You are an action planner for a deterministic text-sim.
+Return ONLY a single JSON object: {"tool": string, "params": object} or null. No prose, no code fences.
+A 'tool_schemas' section and tiny examples will be provided in the user payload; obey them strictly.
+Rules:
+- Choose exactly one tool per turn.
+- Keep params minimal and valid; prefer IDs from context.
+- If no sensible action, return null.
+- If in a conversation and not current speaker, prefer null; consider interject ONLY for brief, meaningful asides.
+- Working memory is provided; consider goals, core memories, and recent perceptions when deciding.
+- When idle: prefer varied low-impact actions like talk with short emotes (e.g., 'nods.', 'hums.'), or wait; avoid repeating the same action consecutively.
+- Avoid selecting 'look' more than once every 5 turns; use it sparingly.
+- Use 'move' only to valid open neighbors.
+- Use 'attack' only if co-located and context justifies.
+- For durations like wait/rest without a number, use ticks=1.
+
+Embodiment and action:
+You are controlling a single embodied actor in a physical world. Choose exactly one concrete next action that physically advances the actor’s goal (e.g., move toward a target, open/close a door, talk/talk_loud when speech itself advances the goal).
+
+Navigation:
+If you intend to investigate something not in your current location, choose move toward an OPEN neighbor from context.location.connections_state. If a connection is closed, choose open (or close) first or pick an alternate OPEN route.
+
+Targeted speech:
+Only use talk/talk_loud when speech itself advances the goal. When speaking to someone present, include target_id. If the relevant person is elsewhere, move instead.
+
+Repetition hint:
+You receive repetition_hint = {last_tool_by_actor, avoid_repeat_within, look_cooldown}. Do not pick last_tool_by_actor again within avoid_repeat_within turns unless necessary. Avoid 'look' within look_cooldown. If you previously indicated you would investigate, prefer 'move' next.
+
+Hidden reasoning:
+Before deciding, write brief hidden reasoning inside <think>...</think>. Then output ONLY one JSON object with the command.
+
+---
+Example Interaction
+---
+Context:
+{
+  "player_id": "npc_sample",
+  "location_id": "town_square",
+  "visible_items": [],
+  "visible_npcs": ["npc_guard"],
+  "inventory_items": [],
+  "stats": {"hp": 10, "max_hp": 10, "hunger_stage": "sated"},
+  "time_tick": 6
+}
+Player input: "I move to the adjacent tavern location."
+LLM output: {"tool":"move","params":{"target_location":"tavern"}}
+
+Any suggestions on how to improve these prompts or structure them better?


### PR DESCRIPTION
## Summary
- Add `llm_prompt_help_request.txt` with player intent and NPC planner prompts
- Include example context and LLM output for sharing online

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a8f51cedac832e8532274fad02ef44